### PR TITLE
for some reason accessing the pipesCount property of a collection lea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+Node 13.x compatibility. Resolves [this bug report](https://github.com/apostrophecms/apostrophe/issues/2120).
+
 ## 1.0.3
 
 URI tolerance change from 1.0.2 now covers connect() with a promise as well.

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function decorate(obj) {
   };
 
   const neverDecorate = [
-    'apply', 'call', 'hasOwnProperty', 'isPrototypeOf', 'propertyIsEnumerable', 'arguments', 'caller', 'callee', 'super_', 'constructor', 'bind'
+    'apply', 'call', 'hasOwnProperty', 'isPrototypeOf', 'propertyIsEnumerable', 'arguments', 'caller', 'callee', 'super_', 'constructor', 'bind', 'pipesCount'
   ];
 
   // Other possible bad things to decorate, but I think I

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emulate-mongo-2-driver",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Emulate the Mongo 2.x nodejs driver on top of the Mongo 3.x nodejs driver, for bc",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
…ds to a crash in node 13; fortunately it is not a method so we do not need to decorate it, just add it to the do not decorate list