### PR TITLE
deprecation free wrappers for the big 'uns: update, remove and insert

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ function decorateCollection(collection) {
 
   newCollection.update = function(selector, doc, _options, callback) {
     var takesCallback = (typeof arguments[arguments.length - 1]) === 'function';
-    var options = (_options && ((typeof _options) === 'object') && _options) || {};
+    var options = _options && ((typeof _options) === 'object') ? _options : {};
     var multi;
     var atomic;
     multi = options.multi;


### PR DESCRIPTION
This quiets 90% of the "oh geez everything is deprecated!" noise at startup. I had said we would forego this, but realistically we're not going to update all the 2.x code to use newer mongodb methods. Writing deprecation free, equivalent wrappers once makes more sense. It just had to wait for a boring Sunday.

The remaining 10% is this guy:

"DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to the MongoClient constructor."

I don't know enough about the consequences to just up and do that to people by default. However, we could do it by default in the boilerplate project so that this does not impact a typical new user cloning that project.